### PR TITLE
fix(button): 当disabled和ghost一起开启的时候, 在白色背景下会视觉消失的问题

### DIFF
--- a/style/web/components/button/_var.less
+++ b/style/web/components/button/_var.less
@@ -106,4 +106,4 @@
 @btn-text-variant-base-color: @text-color-anti;
 
 // 状态色 - disabled ghost
-@btn-color-ghost-disabled: rgba(255, 255, 255, .22);
+@btn-color-ghost-disabled: @text-color-disabled;


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

![image](https://github.com/Julone/tdesign-common/assets/32406368/d43d1528-f28d-4f95-840d-cc731b26bc7f)
当disabled和ghost一起开启的时候, 在白色背景下会消失的问题

### 💡 需求背景和解决方案

替换变量为文字禁用的颜色, 支持暗黑模式的颜色切换.

### 📝 更新日志

fix(button): 当disabled和ghost一起开启的时候, 在白色背景下会视觉消失的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
